### PR TITLE
Add Ubuntu 16 version case; remove version number catchall

### DIFF
--- a/manifests/client/debian/params.pp
+++ b/manifests/client/debian/params.pp
@@ -18,14 +18,13 @@ class nfs::client::debian::params {
       $service_rpcidmapd = 'nfs-idmapd'
       $service_nfs_restart_cmd = '/usr/bin/systemctl reload nfs-server'
     }
-    # TODO: workaround for Fedora
-    /^\d{2,}/: {
-      $osmajor = 7
+    /^16\.\d+$/: {
+      $osmajor = 16
       $service_nfslock = 'nfs-server'
-      $service_nfs = 'nfs-server'
-      $service_rpcgssd = 'nfs-server'
-      $service_rpcsvcgssd = 'nfs-server'
-      $service_rpcidmapd = 'nfs-server'
+      $service_nfs = 'nfs-client'
+      $service_rpcgssd = 'rpc-gssd'
+      $service_rpcsvcgssd = 'rpc-svcgssd'
+      $service_rpcidmapd = 'nfs-idmapd'
       $service_nfs_restart_cmd = '/usr/bin/systemctl reload nfs-server'
     }
     default:{

--- a/manifests/client/debian/service.pp
+++ b/manifests/client/debian/service.pp
@@ -17,9 +17,10 @@ class nfs::client::debian::service {
 
 
   case $::operatingsystemrelease {
-    /^15\.\d+$/: {
+    /^15\.\d+$/, /^16\.\d+$/: {
       # 15.04 doesn't use idmapd for client side anymore.  Neither does Fedora 22.  It's all done differently without a service
-    }
+   }
+      
     default: {
       if $nfs::client::debian::nfs_v4 {
         service { "$nfs::client::debian::params::service_rpcidmapd":


### PR DESCRIPTION
Fixes 'Could not intern from data: Could not find relationship target "Service[]"' error.
