### PR TITLE
Added support for RHEL to push RPCNFSDCOUNT to /etc/sysconfig/nfs

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -64,6 +64,7 @@ class nfs::server (
   $rpcsvcgssd_opts              = $nfs::params::rpcsvcgssd_opts,
   $rpcidmapd_opts               = $nfs::params::rpcidmapd_opts,
   $rpcmountd_opts               = $nfs::params::rpcmountd_opts,
+  $rpcnfsdcount                 = undef,
   #
   $nfs_v4_root_export_ensure    = 'mounted',
   $nfs_v4_root_export_mount     = undef,
@@ -82,7 +83,8 @@ class nfs::server (
     rpcgssd_opts           => $rpcgssd_opts,
     rpcsvcgssd_opts        => $rpcsvcgssd_opts,
     rpcidmapd_opts         => $rpcidmapd_opts,
-    rpcmountd_opts         => $rpcmountd_opts
+    rpcmountd_opts         => $rpcmountd_opts,
+    rpcnfsdcount           => $rpcnfsdcount
   }
 
   include nfs::server::configure

--- a/manifests/server/rhel.pp
+++ b/manifests/server/rhel.pp
@@ -7,6 +7,7 @@ class nfs::server::rhel(
   $rpcsvcgssd_opts       = undef,
   $rpcidmapd_opts        = undef,
   $rpcmountd_opts        = undef,
+  $rpcnfsdcount          = undef
 ) inherits nfs::server::rhel::params {
 
   if !defined(Class['nfs::client']) {
@@ -23,6 +24,7 @@ class nfs::server::rhel(
   }
 
   include nfs::server::rhel::install,
+          nfs::server::rhel::configure,
           nfs::server::rhel::service
 }
 

--- a/manifests/server/rhel/configure.pp
+++ b/manifests/server/rhel/configure.pp
@@ -1,0 +1,12 @@
+# Shamefully stolen from https://github.com/frimik/puppet-nfs
+# refactored a bit
+
+class nfs::server::rhel::configure {
+
+  concat::fragment { 'rhel-sysconfig-nfs_server':
+    target  => '/etc/sysconfig/nfs',
+    order   => '03',
+    content => template('nfs/rhel-sysconfig-nfs_server.erb'),
+    notify  => [ Service[$nfs::client::rhel::rpcgssd[name]], Service[$nfs::client::rhel::rpcidmapd[name]] ],
+  }  
+}

--- a/manifests/server/rhel/service.pp
+++ b/manifests/server/rhel/service.pp
@@ -32,7 +32,7 @@ class nfs::server::rhel::service {
       hasstatus  => true,
       restart    => $nfs::server::rhel::nfs[restart_cmd],
       require    => Package['nfs-utils'],
-      subscribe  => [ Concat['/etc/exports'], File['/etc/idmapd.conf'], File['/etc/sysconfig/nfs'] ],
+      subscribe  => [ Concat['/etc/exports'], Concat['/etc/idmapd.conf'], Concat['/etc/sysconfig/nfs'] ],
     }
   }
   else {
@@ -43,7 +43,7 @@ class nfs::server::rhel::service {
       hasstatus  => true,
       restart    => $nfs::server::rhel::nfs[restart_cmd],
       require    => Package['nfs-utils'],
-      subscribe  => [ Concat['/etc/exports'], File['/etc/idmapd.conf'], File['/etc/sysconfig/nfs'] ],
+      subscribe  => [ Concat['/etc/exports'], Concat['/etc/idmapd.conf'], Concat['/etc/sysconfig/nfs'] ],
     }
   }
 }

--- a/templates/rhel-sysconfig-nfs_server.erb
+++ b/templates/rhel-sysconfig-nfs_server.erb
@@ -1,0 +1,5 @@
+# NFS Server options - Managed by Puppet
+<% rpcnfsdcount = scope['nfs::server::rpcnfsdcount'] -%>
+<% unless rpcnfsdcount.nil? || rpcnfsdcount == :undef || rpcnfsdcount.empty? -%>
+RPCNFSDCOUNT=<%= rpcnfsdcount %>
+<% end -%>


### PR DESCRIPTION
This will also enable base templating for extra options in the server side NFS config.

The unless statement for scope[] lookups is because puppet3 does not handle undef (:undef) properly and will interpret it as NOT NIL.  Which means you'll end up with RPCNFSDCOUNT=undef
